### PR TITLE
Rename idleTick to idleCallback

### DIFF
--- a/inc/drivers/cutebot/CutebotDistanceSensor.h
+++ b/inc/drivers/cutebot/CutebotDistanceSensor.h
@@ -18,6 +18,6 @@ class CutebotDistanceSensor : public MicroBitComponent
     /**
       * Periodic callback from MicroBit idle thread.
       */
-    virtual void idleTick();
+    virtual void idleCallback();
 };
 #endif

--- a/inc/drivers/cutebot/CutebotLineSensors.h
+++ b/inc/drivers/cutebot/CutebotLineSensors.h
@@ -19,6 +19,6 @@ class CutebotLineSensors : public MicroBitComponent
     /**
       * Periodic callback from MicroBit idle thread.
       */
-    virtual void idleTick();
+    virtual void idleCallback();
 };
 #endif

--- a/inc/drivers/gigglebot/GigglebotBattery.h
+++ b/inc/drivers/gigglebot/GigglebotBattery.h
@@ -18,6 +18,6 @@ class GigglebotBattery : public MicroBitComponent
     /**
       * Periodic callback from MicroBit idle thread.
       */
-    virtual void idleTick();
+    virtual void idleCallback();
 };
 #endif

--- a/inc/drivers/gigglebot/GigglebotLightSensors.h
+++ b/inc/drivers/gigglebot/GigglebotLightSensors.h
@@ -19,6 +19,6 @@ class GigglebotLightSensors : public MicroBitComponent
     /**
       * Periodic callback from MicroBit idle thread.
       */
-    virtual void idleTick();
+    virtual void idleCallback();
 };
 #endif

--- a/inc/drivers/gigglebot/GigglebotLineSensors.h
+++ b/inc/drivers/gigglebot/GigglebotLineSensors.h
@@ -19,6 +19,6 @@ class GigglebotLineSensors : public MicroBitComponent
     /**
       * Periodic callback from MicroBit idle thread.
       */
-    virtual void idleTick();
+    virtual void idleCallback();
 };
 #endif

--- a/source/drivers/cutebot/CutebotDistanceSensor.cpp
+++ b/source/drivers/cutebot/CutebotDistanceSensor.cpp
@@ -47,7 +47,7 @@ uint64_t measurePulseWidthMicroSecs(MicroBitPin* pin) {
 #endif
 }
 
-void CutebotDistanceSensor::idleTick()
+void CutebotDistanceSensor::idleCallback()
 {
     if (++counter < CUTEBOT_PERIOD_DISTANCE_SENSOR)
     {

--- a/source/drivers/cutebot/CutebotLineSensors.cpp
+++ b/source/drivers/cutebot/CutebotLineSensors.cpp
@@ -20,7 +20,7 @@ uint16_t CutebotLineSensors::getRightReading()
     return this->readings[1];
 }
 
-void CutebotLineSensors::idleTick()
+void CutebotLineSensors::idleCallback()
 {
     if (++counter < CUTEBOT_PERIOD_LINE_SENSORS)
     {

--- a/source/drivers/gigglebot/GigglebotBattery.cpp
+++ b/source/drivers/gigglebot/GigglebotBattery.cpp
@@ -9,7 +9,7 @@ GigglebotBattery::GigglebotBattery(MicroBitI2C &_i2c)
 
 uint16_t GigglebotBattery::getVoltage() { return this->voltage; }
 
-void GigglebotBattery::idleTick() {
+void GigglebotBattery::idleCallback() {
   unsigned char command = GET_VOLTAGE_BATTERY;
   unsigned char buffer[2];
 

--- a/source/drivers/gigglebot/GigglebotLightSensors.cpp
+++ b/source/drivers/gigglebot/GigglebotLightSensors.cpp
@@ -11,7 +11,7 @@ uint16_t GigglebotLightSensors::getLeftReading() { return this->readings[1]; }
 
 uint16_t GigglebotLightSensors::getRightReading() { return this->readings[0]; }
 
-void GigglebotLightSensors::idleTick() {
+void GigglebotLightSensors::idleCallback() {
   unsigned char command = GET_LIGHT_SENSORS;
   unsigned char buffer[3];
 

--- a/source/drivers/gigglebot/GigglebotLineSensors.cpp
+++ b/source/drivers/gigglebot/GigglebotLineSensors.cpp
@@ -11,7 +11,7 @@ uint16_t GigglebotLineSensors::getLeftReading() { return this->readings[1]; }
 
 uint16_t GigglebotLineSensors::getRightReading() { return this->readings[0]; }
 
-void GigglebotLineSensors::idleTick() {
+void GigglebotLineSensors::idleCallback() {
   unsigned char command = GET_LINE_SENSORS;
   unsigned char buffer[3];
 


### PR DESCRIPTION
They renamed `idleTick` to `idleCallback` :roll_eyes: 
The distance and line sensors are running now. I'm still having GATT error troubles, but I can see them send at least one value to the UI. And I hear the distance sensor going continuously.