### PR TITLE
Slow down cutebot sensors

### DIFF
--- a/inc/drivers/cutebot/Cutebot.h
+++ b/inc/drivers/cutebot/Cutebot.h
@@ -9,10 +9,10 @@
 
 // Reference: https://github.com/elecfreaks/pxt-cutebot
 
-#define CUTEBOT_PERIOD_LINE_SENSORS          100
+#define CUTEBOT_PERIOD_LINE_SENSORS          300
 #define CUTEBOT_START_COUNT_LINE_SENSORS     0
-#define CUTEBOT_PERIOD_DISTANCE_SENSOR       100
-#define CUTEBOT_START_COUNT_DISTANCE_SENSOR  50
+#define CUTEBOT_PERIOD_DISTANCE_SENSOR       300
+#define CUTEBOT_START_COUNT_DISTANCE_SENSOR  150
 
 // I2C address of the Cutebot
 const char CUTEBOT_I2C_ADDR = 0x10 << 1;


### PR DESCRIPTION
This PR slows down the sampling period of the cutebot line sensors and ultrasonic sensor. The microbit could handle the faster speed just fine, but it was overwhelming the UI.